### PR TITLE
More cleanup for test.py and use rectangle_mask

### DIFF
--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 
 from models.model import Model
 from options.test_options import TestOptions
-from utils.util import center_mask, irregular_mask, rectangle_mask, save_images
+from utils.util import irregular_mask, rectangle_mask, save_images
 
 SUPPORTED_IMAGE_TYPES = ["jpg", "png", "jpeg"]
 
@@ -22,24 +22,31 @@ def load_image(image_file, config):
 
 
 def test(config):
+    entries = []
+    count = 0
+    # Do some basic error checking on the file(s) to process
     if config.test_file_path:
         print(f"Running with single file {config.test_file_path}")
-        count = 0
-
         if config.test_file_path.suffix.lower()[1:] not in SUPPORTED_IMAGE_TYPES:
             raise Exception(f"File {config.test_file_path} is not supported")
         if not config.test_file_path.exists():
             raise Exception(f"File {config.test_file_path} does not exist")
         if not config.test_file_path.is_file():
             raise Exception(f"File {config.test_file_path} is not a file")
-
-        print(f"Processing Image - {config.test_file_path}")
+        entries.append(config.test_file_path)
+    else:
+        print(f"Running with directory {config.test_dir}")
+        for entry in config.test_dir.iterdir():
+            if entry.is_file() and entry.suffix.lower()[1:] in SUPPORTED_IMAGE_TYPES:
+                entries.append(entry)
+    # Process all entries
+    for entry in entries:
         if config.random_mask == 1:
             mask = irregular_mask(config.image_shape[0], config.image_shape[1], config.min_strokes, config.max_strokes)
         else:
             mask = rectangle_mask(config.image_shape[0], config.image_shape[1], shape=config.mask_shape, position=config.mask_position)
 
-        gt_image = load_image(str(config.test_file_path), config)
+        gt_image = load_image(str(entry), config)
         gt_image = np.expand_dims(gt_image, axis=0)
 
         input_image = np.where(mask == 1, 1, gt_image)
@@ -47,39 +54,14 @@ def test(config):
         prediction_coarse, prediction_refine = generator([input_image, mask], training=False)
         prediction_refine = prediction_refine * mask + gt_image * (1 - mask)
 
-        output_file = str(Path(config.testing_dir).joinpath(config.test_file_path.name))
+        output_file = str(Path(config.testing_dir).joinpath(entry.name))
         save_images(input_image[0, ...], gt_image[0, ...], prediction_coarse[0, ...], prediction_refine[0, ...], output_file)
 
         count += 1
+        # I think this is just a way to exit early ?
         if count == config.test_num:
             return
         print("-" * 20)
-    else:
-        count = 0
-        print(f"Running with directory {config.test_dir}")
-        for entry in config.test_dir.iterdir():
-            if entry.is_file() and entry.suffix.lower()[1:] in SUPPORTED_IMAGE_TYPES:
-                print(f"Processing Image - {entry}")
-                if config.random_mask == 1:
-                    mask = irregular_mask(config.image_shape[0], config.image_shape[1], config.min_strokes, config.max_strokes)
-                else:
-                    mask = center_mask(config.image_shape[0], config.image_shape[1])
-
-                gt_image = load_image(str(entry), config)
-                gt_image = np.expand_dims(gt_image, axis=0)
-
-                input_image = np.where(mask == 1, 1, gt_image)
-
-                prediction_coarse, prediction_refine = generator([input_image, mask], training=False)
-                prediction_refine = prediction_refine * mask + gt_image * (1 - mask)
-
-                output_file = str(Path(config.testing_dir).joinpath(entry.name))
-                save_images(input_image[0, ...], gt_image[0, ...], prediction_coarse[0, ...], prediction_refine[0, ...], output_file)
-
-                count += 1
-                if count == config.test_num:
-                    return
-                print("-" * 20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Simplified the `test.py` logic for using a single file or a dir of files
- `test.py` now uses `rectangle_mask` function which supports more configurations than center_mask